### PR TITLE
I fixed the Airflow Kubernetes configuration by standardizing configs…

### DIFF
--- a/10-scheduler-deployment.yaml
+++ b/10-scheduler-deployment.yaml
@@ -86,6 +86,16 @@ spec:
               value: CeleryExecutor
             - name: AIRFLOW__CORE__LOAD_EXAMPLES
               value: "False"
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -99,7 +109,7 @@ spec:
                   name: airflow-redis-password
                   key: password
             - name: AIRFLOW__CELERY__RESULT_BACKEND
-              value: "db+redis://:$(REDIS_PASSWORD)@airflow-redis:6379/1"
+              value: "redis://:$(REDIS_PASSWORD)@airflow-redis:6379/1"
             - name: AIRFLOW__CELERY__BROKER_URL
               valueFrom:
                 secretKeyRef:

--- a/11-worker-deployment.yaml
+++ b/11-worker-deployment.yaml
@@ -42,7 +42,12 @@ spec:
             - "-c"
             - "exec airflow celery worker"
           resources:
-            {}
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
           volumeMounts:
             - name: dags-volume
               mountPath: "/opt/airflow/dags"
@@ -65,6 +70,16 @@ spec:
               value: CeleryExecutor
             - name: AIRFLOW__CORE__LOAD_EXAMPLES
               value: "False"
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/5b-airflow-config-configmap.yaml
+++ b/5b-airflow-config-configmap.yaml
@@ -19,7 +19,7 @@ data:
     kubernetes_queue = kubernetes
 
     [database] # Changed from [core] for sql_alchemy_conn as per modern practice
-    sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres-service/airflow
+    # sql_alchemy_conn = postgresql+psycopg2://airflow:airflow@postgres-service/airflow # Overridden by env var AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
 
     [core]
     # auth_manager = airflow.auth.managers.simple_auth_manager.SimpleAuthManager
@@ -88,3 +88,23 @@ data:
 
   airflow_local_settings.py: |-
 ---
+
+  pod_template_file.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: dummy-pod-template # Name can be anything here, it's a template
+    spec:
+      # restartPolicy: Never # Common for task pods
+      containers:
+      - name: base
+        image: "" # This will be overridden by Airflow or specific task definitions
+        imagePullPolicy: IfNotPresent
+        # args: ["echo", "This is a dummy pod template for Airflow."]
+        # resources:
+        #   limits:
+        #     memory: "1Gi"
+        #     cpu: "1"
+        #   requests:
+        #     memory: "512Mi"
+        #     cpu: "0.5"

--- a/9-airflow-dag-processor-deploy.yaml
+++ b/9-airflow-dag-processor-deploy.yaml
@@ -61,6 +61,16 @@ spec:
               value: CeleryExecutor
             - name: AIRFLOW__CORE__LOAD_EXAMPLES
               value: "False"
+            - name: AIRFLOW__CORE__FERNET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-fernet-key
+                  key: fernet-key
+            - name: AIRFLOW__WEBSERVER__SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-webserver-secret-key
+                  key: webserver-secret-key
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
…, adding missing keys, and setting resources. Here's what I did:

- I standardized AIRFLOW__CELERY__RESULT_BACKEND to use Redis across all components.
- I added the missing AIRFLOW__CORE__FERNET_KEY to the scheduler, worker, and DAG processor.
- I added the missing AIRFLOW__WEBSERVER__SECRET_KEY to the scheduler, worker, and DAG processor.
- I added a default pod_template_file.yaml to the airflow-config ConfigMap to prevent mount errors.
- I set resource requests and limits for Airflow workers to prevent OOMKilled errors.
- I commented out the redundant sql_alchemy_conn in airflow.cfg as it's overridden by environment variables.